### PR TITLE
feat: embed lofi playlist from spotify

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,19 +1,17 @@
 <script setup>
 import PomodoroTimer from './components/PomodoroTimer.vue'
-// importing onMounted from vue
+import SpotifyPlayer from './components/SpotifyPlayer.vue'
+
 import { ref, onMounted } from 'vue'
 
-// reactive state for light/dark mode
 const isDarkMode = ref(localStorage.getItem('mode') === 'dark')
 
-// function to toggle light/dark mode
 const toggleMode = () => {
   isDarkMode.value = !isDarkMode.value
   document.body.classList.toggle('dark-mode', isDarkMode.value)
   localStorage.setItem('mode', isDarkMode.value ? 'dark' : 'light')
 }
 
-// on mount
 onMounted(() => {
   if (isDarkMode.value) {
     document.body.classList.add('dark-mode')
@@ -22,16 +20,17 @@ onMounted(() => {
 </script>
 
 <template>
-  <!--adding a div to wrap the content and apply the dark-mode class conditionally-->
   <div :class="{ 'dark-mode': isDarkMode }" class="body-container">
-    <!--title-->
     <h1>Welcome to Cuchi Pomodoro</h1>
-    <!--toggle button-->
     <button class="button" @click="toggleMode">
       {{ isDarkMode ? 'Switch to Light Mode' : 'Switch to Dark Mode' }}
     </button>
-    <!--pomodoro timer component-->
-    <PomodoroTimer></PomodoroTimer>
+
+    <!-- Pomodoro Timer -->
+    <PomodoroTimer />
+
+    <!-- Spotify Player -->
+    <SpotifyPlayer />
   </div>
 </template>
 

--- a/src/components/SpotifyPlayer.vue
+++ b/src/components/SpotifyPlayer.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="spotify-player">
+    <iframe
+      style="border-radius:12px"
+      src="https://open.spotify.com/embed/playlist/2YC6RDAdPt3J4yD2aJMtjt?utm_source=generator&theme=0"
+      width="400"
+      height="150"
+      frameborder="0"
+      allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+      loading="lazy"
+    ></iframe>
+  </div>
+</template>
+
+<script setup>
+</script>
+
+<style scoped>
+.spotify-player {
+  position: absolute;
+  bottom: 20px;
+  right: 20px;
+  z-index: 100;
+}
+</style>


### PR DESCRIPTION
## Description
To enhance the user experience during work sessions, adding a Spotify playlist embed (e.g., a lofi playlist) would allow users to listen to background music while working. This can help increase focus and create a more enjoyable environment during Pomodoro sessions.

- **What does this pull request accomplish?**
Add embed lofi music playlist from Spotify
![image](https://github.com/user-attachments/assets/7ee3abba-8320-4707-b8c1-b252d1f6e97f)

## Checklist
Please check the following boxes before submitting your pull request:

- [x] I have read the contributing guidelines.
- [x] My code follows the existing style guidelines.
- [x] I have tested my changes and included tests where applicable.
- [x] I have updated the documentation if necessary.
- [x] I have added relevant screenshots (if applicable).

## Related Issues
- Closes #16 
