### PR TITLE
feat(timer): show on the title bar of browser

### DIFF
--- a/src/components/PomodoroTimer.vue
+++ b/src/components/PomodoroTimer.vue
@@ -1,6 +1,7 @@
 <script setup>
-import { ref, onMounted, onUnmounted, computed } from 'vue'
+import { ref, watch, onUnmounted, computed } from 'vue'
 
+const originalTitle = document.title;
 const props = defineProps({
   initialWorkTime: {
     type: Number,
@@ -72,8 +73,22 @@ const seconds = computed(() => {
   return (timeLeft.value % 60).toString().padStart(2, '0')
 })
 
+const formattedTime = computed(() => {
+  return `${minutes.value}:${seconds.value}`
+})
+
+watch([formattedTime, timerRunning], ([newTime, running]) => {
+  if (running) {
+    document.title = timeLeft.value > 0 ? `${newTime} - ${originalTitle}` : `Time's up! - ${originalTitle}`
+  } else {
+    document.title = originalTitle
+  }
+})
+
 onUnmounted(() => {
   clearInterval(timerInterval)
+  // Restore the original title when the component is unmounted
+  document.title = originalTitle
 })
 </script>
 


### PR DESCRIPTION
# Pull Request Template

## Description
Please include a summary of the changes you made and the purpose of this pull request. Describe any key points that reviewers should focus on.

- **What does this pull request accomplish?**
Show the timer on the title bar of the browser, so when the user is not on the pomodoro app user will still able to see the timer by tab of title bar.

![image](https://github.com/user-attachments/assets/abfa3196-4cb3-49af-8301-7beb0561702e)


- **What issue does this resolve?** (if applicable)

## Checklist
Please check the following boxes before submitting your pull request:

- [x] I have read the contributing guidelines.
- [x] My code follows the existing style guidelines.
- [x] I have tested my changes and included tests where applicable.
- [x] I have updated the documentation if necessary.
- [x] I have added relevant screenshots (if applicable).

## Related Issues
If this pull request addresses any existing issues, please list them here. Use the format `Closes #issue_number` to link the issue.

- Closes #39 
