### PR TITLE
fix: remove conflicting required props and stop timer on mode switch

### DIFF
--- a/src/components/PomodoroTimer.vue
+++ b/src/components/PomodoroTimer.vue
@@ -5,12 +5,10 @@ const originalTitle = document.title;
 const props = defineProps({
   initialWorkTime: {
     type: Number,
-    required: true,
     default: 25 * 60, // 25 minutes in seconds
   },
   initialBreakTime: {
     type: Number,
-    required: true,
     default: 5 * 60, // 5 minutes in seconds
   },
   soundEnabled: {
@@ -57,6 +55,8 @@ const resumeTimer = () => {
 }
 
 const switchTimerMode = () => {
+  clearInterval(timerInterval)
+  timerRunning.value = false
   isWorkTime.value = !isWorkTime.value
   timeLeft.value = isWorkTime.value
     ? props.initialWorkTime


### PR DESCRIPTION
## 🐛 Fix: Timer Props & Skip Mode Bug

### Problems

**1. Conflicting prop definitions**
`initialWorkTime` and `initialBreakTime` had both `required: true` and `default` set simultaneously. In Vue, these are mutually exclusive — if a prop is required, the default is never used and Vue throws a warning in the console.

**2. Timer interval not cleared on skip**
Calling `switchTimerMode` while the timer was running did not stop the active interval, causing the old interval to keep running in the background alongside the new one, producing unexpected behavior.

### Solution

- Removed `required: true` from `initialWorkTime` and `initialBreakTime` — defaults now work as intended
- Added `clearInterval(timerInterval)` and `timerRunning.value = false` at the start of `switchTimerMode` to ensure a clean state before switching modes

### Changes
| File | Change |
|---|---|
| `src/components/PomodoroTimer.vue` | Removed conflicting `required: true` from props |
| `src/components/PomodoroTimer.vue` | Fixed `switchTimerMode` to clear interval on skip |

### Testing
1. Run `npm run dev`
2. Start the timer and click **Skip to Break** — timer should stop and reset cleanly
3. Check browser console — no Vue prop warnings should appear
4. Run `npm run test:unit` — all tests should pass