### PR TITLE
replaced magic numbers with fixed constants

### DIFF
--- a/src/components/PomodoroTimer.vue
+++ b/src/components/PomodoroTimer.vue
@@ -2,15 +2,19 @@
 import { ref, watch, onUnmounted, computed } from 'vue'
 import tickingBellUrl from '@/assets/sound/timer-with-chime.mp3'
 
+const WORK_DURATION_SECONDS = 25 * 60
+const BREAK_DURATION_SECONDS = 5 * 60
+const CHIME_TRIGGER_SECONDS = 11
+
 const originalTitle = document.title;
 const props = defineProps({
   initialWorkTime: {
     type: Number,
-    default: 25 * 60, // 25 minutes in seconds
+    default: WORK_DURATION_SECONDS,
   },
   initialBreakTime: {
     type: Number,
-    default: 5 * 60, // 5 minutes in seconds
+    default: BREAK_DURATION_SECONDS,
   },
   soundEnabled: {
     type: Boolean,
@@ -39,7 +43,7 @@ const startTimer = () => {
   timerInterval.value = setInterval(() => {
     timeLeft.value--
 
-    if (timeLeft.value === 11 && props.soundEnabled) {
+    if (timeLeft.value === CHIME_TRIGGER_SECONDS && props.soundEnabled) {
       tickingBellSound.play()
     }
 

--- a/src/components/PomodoroTimer.vue
+++ b/src/components/PomodoroTimer.vue
@@ -2,19 +2,17 @@
 import { ref, watch, onUnmounted, computed } from 'vue'
 import tickingBellUrl from '@/assets/sound/timer-with-chime.mp3'
 
-const WORK_DURATION_SECONDS = 25 * 60
-const BREAK_DURATION_SECONDS = 5 * 60
 const CHIME_TRIGGER_SECONDS = 11
 
 const originalTitle = document.title;
 const props = defineProps({
   initialWorkTime: {
     type: Number,
-    default: WORK_DURATION_SECONDS,
+    default: 25 * 60,
   },
   initialBreakTime: {
     type: Number,
-    default: BREAK_DURATION_SECONDS,
+    default: 5 * 60,
   },
   soundEnabled: {
     type: Boolean,


### PR DESCRIPTION
## Description
Added constants at the top of `PomodoroTImer.vue`
```js
WORK_DURATION_SECONDS
BREAK_DURATION_SECONDS
CHIME_TRIGGER_SECONDS
```
Then replaced raw numeric literals with those constants in the props defaults and chime trigger logic.

- Closes #65 
