### PR TITLE
feat: allow user configure their city in the weather widget

### DIFF
--- a/src/components/WeatherComponent.vue
+++ b/src/components/WeatherComponent.vue
@@ -1,6 +1,18 @@
 <template>
   <div class="weather-widget">
     <h2>Weather in {{ city }}</h2>
+    <div class="weather-controls">
+      <select
+        v-model="selectedCity"
+        class="weather-select"
+        aria-label="Weather city"
+        @change="updateCity"
+      >
+        <option v-for="option in cityOptions" :key="option.city" :value="option.city">
+          {{ option.city }} ({{ option.gmt }})
+        </option>
+      </select>
+    </div>
     <!-- Loading spinner -->
     <div v-if="loading" class="loading-spinner">
       <div class="spinner"></div>
@@ -11,16 +23,21 @@
       <p>{{ error }}</p>
     </div>
     <!-- Weather data -->
-    <div v-else-if="weatherData">
-      <img
-        class="weather-icon"
-        :src="`https://openweathermap.org/img/wn/${weatherData.weather[0].icon}.png`"
-        :alt="weatherData.weather[0].description"
-      />
-      <p>Temperature: {{ weatherData.main.temp }}°C</p>
-      <p>Condition: {{ weatherData.weather[0].description }}</p>
-      <p>Humidity: {{ weatherData.main.humidity }}%</p>
-      <p>Wind Speed: {{ weatherData.wind.speed }} m/s</p>
+    <div v-else-if="weatherData" class="weather-content">
+      <div class="weather-details">
+        <p>Temperature: {{ weatherData.main.temp }}°C</p>
+        <p>Condition: {{ weatherData.weather[0].description }}</p>
+        <p>Humidity: {{ weatherData.main.humidity }}%</p>
+        <p>Wind Speed: {{ weatherData.wind.speed }} m/s</p>
+        <p>GMT: {{ selectedGmt }}</p>
+      </div>
+      <div class="weather-icon-frame">
+        <img
+          class="weather-icon"
+          :src="`https://openweathermap.org/img/wn/${weatherData.weather[0].icon}.png`"
+          :alt="weatherData.weather[0].description"
+        />
+      </div>
     </div>
   </div>
 </template>
@@ -28,20 +45,49 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 
+const cityOptions = [
+  { city: 'Boston', gmt: 'GMT-05:00' },
+  { city: 'Mexico City', gmt: 'GMT-06:00' },
+  { city: 'Monterrey', gmt: 'GMT-06:00' },
+  { city: 'Guadalajara', gmt: 'GMT-06:00' },
+  { city: 'Caracas', gmt: 'GMT-04:00' },
+  { city: 'Lima', gmt: 'GMT-05:00' },
+  { city: 'Santiago', gmt: 'GMT-03:00' },
+  { city: 'Buenos Aires', gmt: 'GMT-03:00' },
+  { city: 'Sao Paulo', gmt: 'GMT-03:00' },
+  { city: 'Cape Town', gmt: 'GMT+02:00' },
+  { city: 'Miami', gmt: 'GMT-05:00' },
+  { city: 'New York', gmt: 'GMT-05:00' },
+  { city: 'Los Angeles', gmt: 'GMT-08:00' },
+  { city: 'London', gmt: 'GMT+00:00' },
+  { city: 'Madrid', gmt: 'GMT+01:00' },
+  { city: 'Tokyo', gmt: 'GMT+09:00' },
+]
+
+const savedCity = localStorage.getItem('weatherCity')
+const defaultCity = cityOptions.some((option) => option.city === savedCity) ? savedCity : 'Boston'
+const defaultGmt = cityOptions.find((option) => option.city === defaultCity)?.gmt || 'GMT-05:00'
+
 const apiKey = import.meta.env.VITE_WEATHER_API_KEY
-const city = ref('Boston')
+const city = ref(defaultCity)
+const selectedCity = ref(defaultCity)
+const selectedGmt = ref(defaultGmt)
 const weatherData = ref(null)
 const loading = ref(true)
 const error = ref(null)
 
 async function fetchWeather() {
+  loading.value = true
+  error.value = null
+  weatherData.value = null
+
   if (!apiKey) {
     error.value = 'Weather API key is missing. Please check your environment variables.'
     loading.value = false
     return
   }
 
-  const apiUrl = `https://api.openweathermap.org/data/2.5/weather?q=${city.value}&appid=${apiKey}&units=metric`
+  const apiUrl = `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(city.value)}&appid=${apiKey}&units=metric`
   try {
     const response = await fetch(apiUrl)
     if (!response.ok) {
@@ -63,6 +109,16 @@ async function fetchWeather() {
   } finally {
     loading.value = false
   }
+}
+
+function updateCity() {
+  const nextCity = selectedCity.value
+  const nextGmt = cityOptions.find((option) => option.city === nextCity)?.gmt || selectedGmt.value
+
+  city.value = nextCity
+  selectedGmt.value = nextGmt
+  localStorage.setItem('weatherCity', city.value)
+  fetchWeather()
 }
 
 onMounted(fetchWeather)
@@ -87,16 +143,49 @@ h2 {
   margin-bottom: 10px;
   color: #4e663a;
 }
+.weather-controls {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+.weather-select {
+  min-width: 0;
+  flex: 1;
+  border: 1px solid #4e663a;
+  border-radius: 6px;
+  padding: 6px 8px;
+  font-family: inherit;
+  font-size: 12px;
+  color: #dfdfdf;
+  background-color: rgba(255, 255, 255, 0.08);
+}
+.weather-select:focus {
+  outline: 2px solid #789679;
+  outline-offset: 1px;
+}
 p {
   margin: 5px 0;
+}
+.weather-content {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+.weather-details {
+  min-width: 0;
+  flex: 1;
+}
+.weather-icon-frame {
+  display: flex;
+  flex: 0 0 48px;
+  align-items: center;
+  justify-content: center;
 }
 .weather-icon {
   width: 40px;
   height: 40px;
-  display: flex;
-  position: absolute;
-  right: 5px;
-  bottom: 110px;
+  display: block;
 }
 
 .loading-spinner {
@@ -138,11 +227,8 @@ p {
     bottom: auto;
     left: auto;
   }
-
-  .weather-icon {
-    position: static;
-    float: right;
-    margin: 0 0 0 0.75rem;
+  .weather-controls {
+    flex-wrap: wrap;
   }
 }
 </style>

--- a/src/components/__tests__/WeatherComponent.test.js
+++ b/src/components/__tests__/WeatherComponent.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/vue'
+import WeatherComponent from '../WeatherComponent.vue'
+
+const weatherResponse = {
+  weather: [{ icon: '01d', description: 'clear sky' }],
+  main: { temp: 22, humidity: 45 },
+  wind: { speed: 3 },
+}
+
+describe('WeatherComponent', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.stubEnv('VITE_WEATHER_API_KEY', 'test-api-key')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(weatherResponse),
+      }),
+    )
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  it('fetches Boston weather by default', async () => {
+    render(WeatherComponent)
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        'https://api.openweathermap.org/data/2.5/weather?q=Boston&appid=test-api-key&units=metric',
+      )
+    })
+
+    expect(screen.getByText('Weather in Boston')).toBeDefined()
+  })
+
+  it('initializes the city from localStorage', async () => {
+    localStorage.setItem('weatherCity', 'Monterrey')
+
+    render(WeatherComponent)
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        'https://api.openweathermap.org/data/2.5/weather?q=Monterrey&appid=test-api-key&units=metric',
+      )
+    })
+
+    expect(screen.getByLabelText('Weather city').value).toBe('Monterrey')
+  })
+
+  it('saves and fetches weather for the selected city', async () => {
+    render(WeatherComponent)
+
+    await fireEvent.update(screen.getByLabelText('Weather city'), 'Mexico City')
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenLastCalledWith(
+        'https://api.openweathermap.org/data/2.5/weather?q=Mexico%20City&appid=test-api-key&units=metric',
+      )
+    })
+
+    expect(localStorage.getItem('weatherCity')).toBe('Mexico City')
+    expect(screen.getByText('Weather in Mexico City')).toBeDefined()
+    expect(screen.getByText('GMT: GMT-06:00')).toBeDefined()
+  })
+
+  it('shows GMT in the city selector options', () => {
+    render(WeatherComponent)
+
+    expect(screen.getByRole('option', { name: 'Boston (GMT-05:00)' })).toBeDefined()
+    expect(screen.getByRole('option', { name: 'Mexico City (GMT-06:00)' })).toBeDefined()
+  })
+})


### PR DESCRIPTION
# Pull Request Template

## Description
The weather widget is hardcoded to display weather for Boston. Users in other locations get irrelevant data.
Add a small select field where the user can choose their city name. Save the value to localStorage so it persists across sessions.

- **What issue does this resolve?** 
#64

## Checklist
Please check the following boxes before submitting your pull request:

- [x] I have read the contributing guidelines.
- [x] My code follows the existing style guidelines.
- [x] I have tested my changes and included tests where applicable.
- [x] I have updated the documentation if necessary.
- [x] I have added relevant screenshots (if applicable).

## Screenshots
<img width="299" height="294" alt="Screenshot 2026-06-02 at 2 05 48 p m" src="https://github.com/user-attachments/assets/bf696953-7324-4d2a-b2dd-ff38a513115b" />



## Related Issues
If this pull request addresses any existing issues, please list them here. Use the format `Closes #issue_number` to link the issue.

- Closes #64
